### PR TITLE
scp images/*jpg instead of scp "images/*jpg"

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ directory inside deepdream as follows:
 
 ```
 #From your local machine
-scp "images/*jpg" root@1.2.3.4:~/clouddream/deepdream/inputs/
+scp images/*jpg root@1.2.3.4:~/clouddream/deepdream/inputs/
 ```
 
 ## Processing a YouTube video


### PR DESCRIPTION
scp "images/_jpg" (...) gives:
images/_.jpg: No such file or directory

scp images/*jpg (...) works.
