### PR TITLE
Allows configuring more parameters @ settings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ http://1.2.3.4/log.html
 
 You can view the current image being processed:
 ```
-http://1.2.3.4/input.jpg
+http://1.2.3.4/image.jpg
 ```
 
 You can view the current settings:
@@ -232,7 +232,7 @@ Inside deepdream/settings.json you'll find a settings file that looks like this:
 ```
 
 You can change `maxwidth` to something larger like 1000 if you want
-big output images for big input images, remeber that will you need more RAM memory
+big output images for big input images, remember that will you need more RAM memory
 for processing lager images. For testing `maxwidth` of 200
 will give you results much faster.  If you change the settings and
 want to regenerate outputs for your input images, simply remove the
@@ -365,6 +365,18 @@ in this demo. Note that the ReLU and Dropout layers are not valid for deepdreami
 "inception_5b/pool_proj"
 "inception_5b/output"
 ```
+
+Here's the full list of supported properties of `settings.json`:
+
+ Property Name | Default Value | Description
+---------------|:-------------:|-------------
+  maxwidth     | 400           | Maximum width in pixels of output images
+  iter_n       | 10            | Number of iterations of the "deepdream" function
+  octave_n     | 4             | Number of octaves
+  octave_scale | 1.4           | Scale of each octave
+  layer        | "inception_4c/output" | The network layer to optimize
+  step_size    | 1.5 | "make_step" parameter, step size
+  jitter       | 32 | how much to "jitter" the image before processing
 
 ### The GUI
 

--- a/deepdream/deepdream.py
+++ b/deepdream/deepdream.py
@@ -16,7 +16,7 @@ def showarray(a, fmt='jpeg'):
     display(Image(data=f.getvalue()))
 
 with open("settings.json") as json_file:
-    json_data = json.load(json_file)
+    settings = json.load(json_file)
     #print()
 
 
@@ -97,7 +97,7 @@ def deepdream(net, base_img, iter_n=10, octave_n=4, octave_scale=1.4, end='incep
     return deprocess(net, src.data[0])
 
 
-maxwidth = json_data['maxwidth']
+maxwidth = settings.get('maxwidth', 400)
 img = PIL.Image.open('input.jpg')
 width = img.size[0]
 
@@ -111,7 +111,13 @@ img = np.float32(img)
 frame = img
 #frame_i = 0
 
-frame = deepdream(net, frame, end=json_data['layer'])
+frame = deepdream(net, frame,
+                  iter_n       = settings.get('iter_n', 10),
+                  octave_n     = settings.get('octave_n', 4),
+                  octave_scale = settings.get('octave_scale', 1.4),
+                  end          = settings.get('layer', 'inception_4c/output'),
+                  step_size    = settings.get('step_size', 1.5),
+                  jitter       = settings.get('jitter', 32))
 #frame = deepdream(net, img, end='inception_3b/5x5_reduce')
 #frame = deepdream(net, img, end='conv2/3x3')
 


### PR DESCRIPTION
This change keeps retro-compatibility, but allows one to configure not
only "layer" and "maxwidth" but all all the parameters taken by the
"deepdream" and "make_step" functions (e.g. octaves, iter_n, jitter).

It also allows one to omit maxwidth and layer by specifying defaults in
the code.
