### PR TITLE
Fix nginx 403 errors on images.json file

### DIFF
--- a/deepdream/make_json.sh
+++ b/deepdream/make_json.sh
@@ -14,6 +14,8 @@ make_json () {
 cd outputs
 
 rm ../temp.json 2>/dev/null
+touch ../temp.json
+chmod 644 ../temp.json
 echo -n "[" > ../temp.json
 
 nfiles=`find . -type f -not -path '*/\.*' | wc -l`


### PR DESCRIPTION
Fixed permissions during initial images.json file creation so file is readable
