### PR TITLE
Fix handling of filenames with spaces

### DIFF
--- a/deepdream/make_json.sh
+++ b/deepdream/make_json.sh
@@ -25,7 +25,7 @@ counter=1
 find . -type f -not -path '*/\.*' -print0 | while read -d $'\0' f;
 do
     id=$counter
-    name=`basename $f`
+    name="$( basename "$f" )"
     src="/outputs/$name"
     echo -n "{\"id\":\"$id\",\"name\":\"$name\",\"src\":\"$src\"}" >> ../temp.json
     if [ "$id" != "$nfiles" ]; then

--- a/deepdream/make_json.sh
+++ b/deepdream/make_json.sh
@@ -26,7 +26,7 @@ find . -type f -not -path '*/\.*' -print0 | while read -d $'\0' f;
 do
     id=$counter
     name="$( basename "$f" )"
-    src="/outputs/$name"
+    src="/outputs/$f"
     echo -n "{\"id\":\"$id\",\"name\":\"$name\",\"src\":\"$src\"}" >> ../temp.json
     if [ "$id" != "$nfiles" ]; then
 	echo -n "," >> ../temp.json

--- a/deepdream/process_images_once.sh
+++ b/deepdream/process_images_once.sh
@@ -4,23 +4,23 @@
 # Copyright vision.ai, 2015
 
 cd /opt/deepdream/inputs
-find . -type f -not -path '*/\.*' -print0 | while read -d $'\0' f;
-do
-    cd /opt/deepdream
-    if [ -e outputs/${f} ];
-    then
-	echo "File ${f} already processed"
+find . -type f -not -path '*/\.*' -print0 | while read -d $'\0' f; do
+    if [[ "$(basename $(pwd))" == *'inputs'* ]]; then
+        cd /opt/deepdream
+    fi
+    if [ -e "outputs/${f}" ]; then
+        echo "File ${f} already processed"
     else
-	echo "Deepdream" ${f}
-	chmod gou+r inputs/${f}
-	cp inputs/${f} input.jpg
-	python deepdream.py
-	ERROR_CODE=$?
-	echo "Error Code is" ${ERROR_CODE}
-	cp output.jpg outputs/${f}
-	rm output.jpg
-	echo "Just created" outputs/${f}
+        echo "Deepdream  ${f}"
+        chmod gou+r "inputs/${f}"
+        cp "inputs/${f}" input.jpg
+        python deepdream.py
+        ERROR_CODE=$?
+        echo -e "Error Code is: ${ERROR_CODE}\n\n"
+        dirname_f="$(dirname "$f")"
+        [[ -d "inputs/$dirname_f" && "$dirname_f" != '.' && "$dirname_f" != *'/deepdream/'* && ! -d "outputs/$dirname_f" ]] && mkdir -p "outputs/${dirname_f}"
+        cp output.jpg "outputs/${f}"
+        rm output.jpg
+        echo "Just created outputs/${f}"
     fi
 done
-
-


### PR DESCRIPTION
In some of the bash scripts, filenames with spaces were not handled appropriately so I fixed this.

Also, I added the ability to handle nested sub-directories in the `inputs/` dir, and output them in matching nested sub-dirs under `outputs/`
