### PR TITLE
Check if container is created/running before stopping/removing

### DIFF
--- a/stop.sh
+++ b/stop.sh
@@ -3,5 +3,19 @@
 # Start the docker container which will keep looking for images inside
 # the inputs/ directory and spew out results into outputs/
 
-docker stop deepdream-files deepdream-compute deepdream-json deepdream-enter
-docker rm deepdream-files deepdream-compute deepdream-json deepdream-enter
+CONTAINER=deepdream_enter
+STOP_CONTAINER=''
+REMOVE_CONTAINER=''
+TRUE='true'
+
+RUNNING=$(docker inspect --format="{{ .State.Running }}" $CONTAINER 2> /dev/null)
+
+if [ $? -eq 0 ]; then
+    REMOVE_CONTAINER=$CONTAINER
+    if [ "$RUNNING" = "$TRUE" ]; then
+        STOP_CONTAINER=$CONTAINER
+    fi
+fi
+
+docker stop deepdream-files deepdream-compute deepdream-json ${STOP_CONTAINER}
+docker rm deepdream-files deepdream-compute deepdream-json ${REMOVE_CONTAINER}


### PR DESCRIPTION
**Method**
Helper scripts are available to start/stop/enter containers.

**Expected Behavior**
When executing the `stop.sh` script containers should be stop and removed

**Actual Result**
While the scripts is able stop/remove the containers called in `start.sh` an error appears.

**Cause**
The `docker` command to stop/remove containers list the `deepdream-enter` container that may not always have been created/running.

**Solution**
Check the status of the `deepdream-enter`  container before trying to stop/remove it.
## 

Fixes #35
